### PR TITLE
Include ability to filter/query returned events

### DIFF
--- a/win32/wevtapi/helpers.go
+++ b/win32/wevtapi/helpers.go
@@ -283,7 +283,7 @@ func NewPullEventProvider() *PullEventProvider {
 }
 
 // FetchEvents implements EventProvider interface
-func (e *PullEventProvider) FetchEvents(channels []string, flag int) (c chan *XMLEvent) {
+func (e *PullEventProvider) FetchEvents(channels []string, flag int, query string) (c chan *XMLEvent) {
 	// Prep the chan
 	c = make(chan *XMLEvent, 242)
 	events := make([]win32.HANDLE, len(channels))
@@ -310,7 +310,7 @@ func (e *PullEventProvider) FetchEvents(channels []string, flag int) (c chan *XM
 			EVT_HANDLE(win32.NULL),
 			events[i],
 			channel,
-			"*",
+			query,
 			EVT_HANDLE(win32.NULL),
 			win32.PVOID(win32.NULL),
 			win32.DWORD(flag))


### PR DESCRIPTION
This is useful when you're interested in a subset of events, and it's quite easy to query using XPath. One use case that's quite common is to subscribe to events from a particular Event Record ID onwards. As-is, the library only currently allow you to subscribe to any **new** events, or to events starting from the oldest record. However, it's quite common to have a scenario similar to "bookmarking":

As we receive an process events, note the event record ID. In case of a disruption or other unforeseen event, load the last processed event record ID and start processing from that record ID onwards (some additional logic is required in case of event record ID rollover). In this scenario, the function call now becomes:

```
eventProvider := wevtapi.NewPullEventProvider()
xmlEvents := eventProvider.FetchEvents([]string{"Application"}, wevtapi.EvtSubscribeStartAtOldestRecord, "Event[System[EventRecordID > 8000]]")
```
Note the last (new) argument which is an XPath query. 

To revert back to default behavior, simply set the last argument to `"*"`